### PR TITLE
Task sounds, amber muted state, badge counter, remount safety

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Vet Radar Notification",
-  "version": "1.3",
+  "version": "1.4",
   "manifest_version": 3,
   "background": {
     "service_worker": "background.js"

--- a/monitor.js
+++ b/monitor.js
@@ -120,8 +120,9 @@ function drainQueue() {
     clone.play().catch(err => {
         if (err?.name === 'NotAllowedError') {
             audioPrimed = false;   // autoplay gate not unlocked — re-prime on next interaction
-            log('WARN', 'Audio', `Autoplay blocked for ${type} — will play after next page interaction`);
-            if (isMonitoring) setWidgetState('muted');
+            mutedChimeCount++;
+            log('WARN', 'Audio', `Autoplay blocked for ${type} — will play after next page interaction (${mutedChimeCount} missed)`);
+            if (isMonitoring) { setWidgetState('muted'); updateBadge(); }
         } else {
             log('ERROR', 'Audio', `play() failed for ${type}: ${err.message}`);
         }
@@ -376,20 +377,32 @@ function primeAudio() {
             clone.pause();
             if (!audioPrimed) {
                 audioPrimed = true;
+                mutedChimeCount = 0;
                 log('INFO', 'Audio', 'Autoplay gate unlocked — sound enabled');
-                if (isMonitoring) setWidgetState('active');
+                if (isMonitoring) { setWidgetState('active'); updateBadge(); }
             }
         }).catch(() => {});
     }
 }
 
-let isMonitoring  = false;
-let userActivated = false;
-let initialized   = false;
-let updateCount   = 0;
-let errCount      = 0;
-let lastUpdate    = null;
-const MAX_ERRORS  = 5;
+let isMonitoring    = false;
+let userActivated   = false;
+let initialized     = false;
+let updateCount     = 0;
+let errCount        = 0;
+let lastUpdate      = null;
+let mutedChimeCount = 0;
+const MAX_ERRORS    = 5;
+
+function updateBadge() {
+    const w = document.getElementById('vr-monitor-widget');
+    if (!w) return;
+    if (mutedChimeCount > 0) {
+        w.dataset.badge = mutedChimeCount > 9 ? '9+' : String(mutedChimeCount);
+    } else {
+        delete w.dataset.badge;
+    }
+}
 const INSTANCE_ID = Math.random().toString(36).slice(2, 7);
 
 // Returns the first stack frame outside this function — i.e. who called us.
@@ -409,8 +422,10 @@ function startMonitoring() {
     lastUpdate    = null;
     Object.keys(patients).forEach(k => delete patients[k]);
     prevNames = new Set();
+    mutedChimeCount = 0;
     primeAudio();
     setWidgetState(audioPrimed ? 'active' : 'muted');
+    updateBadge();
     safeChrome(() => chrome.storage.local.set({ vrMonitoringActive: true }));
     log('INFO', 'Monitor', 'Monitoring started', { instance: INSTANCE_ID, by: callerLine() });
     startListWatcher();
@@ -420,7 +435,9 @@ function stopMonitoring() {
     isMonitoring = false;
     stopObserver();
     audioQueue.length = 0;
+    mutedChimeCount = 0;
     setWidgetState('inactive');
+    updateBadge();
     reportStatus('inactive');
     safeChrome(() => chrome.storage.local.set({ vrMonitoringActive: false }));
     log('INFO', 'Monitor', 'Monitoring stopped', { instance: INSTANCE_ID, by: callerLine() });
@@ -435,7 +452,7 @@ const WIDGET_CSS = `
         z-index:2147483647; display:flex; align-items:center; justify-content:center;
         box-shadow:0 2px 8px rgba(0,0,0,0.35);
         transition:background-color 0.25s ease, transform 0.1s ease;
-        background-color:#b91c1c; user-select:none;
+        background-color:#b91c1c; user-select:none; overflow:visible;
     }
     #vr-monitor-widget:hover { transform:scale(1.1); }
     #vr-monitor-widget.active { background-color:#15803d; }
@@ -448,6 +465,14 @@ const WIDGET_CSS = `
     @keyframes vr-pulse-amber {
         0%,100% { box-shadow:0 2px 8px rgba(217,119,6,0.4); }
         50%      { box-shadow:0 0 18px 4px rgba(217,119,6,0.85); }
+    }
+    #vr-monitor-widget[data-badge]::after {
+        content: attr(data-badge);
+        position:absolute; top:-6px; right:-6px;
+        min-width:18px; height:18px; padding:0 4px;
+        border-radius:9px; background:#ef4444; color:#fff;
+        font-size:10px; font-weight:bold; line-height:18px; text-align:center;
+        border:2px solid #fff; box-sizing:border-box; pointer-events:none;
     }
 `;
 const ICON_OFF = `<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><line x1="23" y1="9" x2="17" y2="15"/><line x1="17" y1="9" x2="23" y2="15"/></svg>`;

--- a/monitor.js
+++ b/monitor.js
@@ -10,20 +10,23 @@ const cfg = {
     patientAddedVolume: 1.0,
     patientRemovedVolume: 1.0,
     examRoomNotificationVolume: 1.0,
+    taskCompletedVolume: 1.0,
     enablePatientAdded: true,
     enablePatientRemoved: true,
     enableExamRoomNotification: true,
+    enableTaskCompleted: true,
     debug: false,
     isActive: true,
 };
 
 const ALL_KEYS = [
-    'chimeVolume', 'patientAddedVolume', 'patientRemovedVolume', 'examRoomNotificationVolume',
-    'enablePatientAdded', 'enablePatientRemoved', 'enableExamRoomNotification',
+    'chimeVolume', 'patientAddedVolume', 'patientRemovedVolume', 'examRoomNotificationVolume', 'taskCompletedVolume',
+    'enablePatientAdded', 'enablePatientRemoved', 'enableExamRoomNotification', 'enableTaskCompleted',
     'debug', 'isActive', 'vrMonitoringActive',
     'patientAddedFileData', 'patientAddedFileName',
     'patientRemovedFileData', 'patientRemovedFileName',
     'examRoomNotificationFileData', 'examRoomNotificationFileName',
+    'taskCompletedFileData', 'taskCompletedFileName',
 ];
 
 function applySettings(result) {
@@ -31,9 +34,11 @@ function applySettings(result) {
     cfg.patientAddedVolume         = result.patientAddedVolume         ?? 1.0;
     cfg.patientRemovedVolume       = result.patientRemovedVolume       ?? 1.0;
     cfg.examRoomNotificationVolume = result.examRoomNotificationVolume ?? 1.0;
+    cfg.taskCompletedVolume        = result.taskCompletedVolume        ?? 1.0;
     cfg.enablePatientAdded         = result.enablePatientAdded         !== false;
     cfg.enablePatientRemoved       = result.enablePatientRemoved       !== false;
     cfg.enableExamRoomNotification = result.enableExamRoomNotification !== false;
+    cfg.enableTaskCompleted        = result.enableTaskCompleted        !== false;
     cfg.debug                      = result.debug                      ?? false;
     cfg.isActive                   = result.isActive                   !== false;
 }
@@ -49,14 +54,15 @@ function loadSettings(cb) {
 chrome.storage.onChanged.addListener((changes, area) => {
     if (area !== 'local') return;
 
-    const cfgKeys = ['chimeVolume','patientAddedVolume','patientRemovedVolume','examRoomNotificationVolume',
-                     'enablePatientAdded','enablePatientRemoved','enableExamRoomNotification','debug'];
+    const cfgKeys = ['chimeVolume','patientAddedVolume','patientRemovedVolume','examRoomNotificationVolume','taskCompletedVolume',
+                     'enablePatientAdded','enablePatientRemoved','enableExamRoomNotification','enableTaskCompleted','debug'];
     for (const k of cfgKeys) {
         if (changes[k]) cfg[k] = changes[k].newValue;
     }
 
     const soundKeys = ['patientAddedFileData','patientAddedFileName','patientRemovedFileData',
-                       'patientRemovedFileName','examRoomNotificationFileData','examRoomNotificationFileName'];
+                       'patientRemovedFileName','examRoomNotificationFileData','examRoomNotificationFileName',
+                       'taskCompletedFileData','taskCompletedFileName'];
     if (soundKeys.some(k => changes[k])) {
         safeChrome(() => chrome.storage.local.get(soundKeys, r => loadSounds(r)));
     }
@@ -71,7 +77,7 @@ chrome.storage.onChanged.addListener((changes, area) => {
 // ─── Audio ────────────────────────────────────────────────────────────────────
 // 3-item queue, sequential. Clone so rapid events don't cut each other off.
 
-const audioEl = { patientAdded: new Audio(), patientRemoved: new Audio(), examRoomNotification: new Audio() };
+const audioEl = { patientAdded: new Audio(), patientRemoved: new Audio(), examRoomNotification: new Audio(), taskCompleted: new Audio() };
 const audioQueue = [];
 const QUEUE_MAX = 3;
 let audioPlaying = false;
@@ -85,11 +91,12 @@ function loadSounds(result) {
     audioEl.patientAdded.src          = result.patientAddedFileData         || extURL(result.patientAddedFileName         || 'BuddyIn.mp3');
     audioEl.patientRemoved.src        = result.patientRemovedFileData       || extURL(result.patientRemovedFileName       || 'Goodbye.mp3');
     audioEl.examRoomNotification.src  = result.examRoomNotificationFileData || extURL(result.examRoomNotificationFileName || '3_tone_chime-99718.mp3');
+    audioEl.taskCompleted.src         = result.taskCompletedFileData        || extURL(result.taskCompletedFileName        || 'mixkit-bell-notification-933.mp3');
     for (const a of Object.values(audioEl)) a.load();
 }
 
-const volKey = { patientAdded: 'patientAddedVolume', patientRemoved: 'patientRemovedVolume', examRoomNotification: 'examRoomNotificationVolume' };
-const enKey  = { patientAdded: 'enablePatientAdded', patientRemoved: 'enablePatientRemoved', examRoomNotification: 'enableExamRoomNotification' };
+const volKey = { patientAdded: 'patientAddedVolume', patientRemoved: 'patientRemovedVolume', examRoomNotification: 'examRoomNotificationVolume', taskCompleted: 'taskCompletedVolume' };
+const enKey  = { patientAdded: 'enablePatientAdded', patientRemoved: 'enablePatientRemoved', examRoomNotification: 'enableExamRoomNotification', taskCompleted: 'enableTaskCompleted' };
 
 function playChime(type) {
     if (!cfg[enKey[type]]) return;
@@ -113,23 +120,11 @@ function drainQueue() {
 
 // ─── Patient Tracking ─────────────────────────────────────────────────────────
 
-const patients = {};       // { [name]: { InExamRoom, criticalNotes, missed, due, timeSlots } }
+const patients = {};       // { [name]: { InExamRoom, taskCells[] } }
 let prevNames  = new Set();
-let timeSlots  = [];
-const TIME_RE  = /^\d{1,2}:\d{2}(am|pm)$/i;
 
 function getPatientList() {
     return document.querySelector('div[data-testid="PatientList"]');
-}
-
-function scanTimeSlots() {
-    const found = Array.from(document.querySelectorAll('div[data-testid]'))
-        .map(el => el.getAttribute('data-testid'))
-        .filter(id => TIME_RE.test(id));
-    if (found.join(',') !== timeSlots.join(',')) {
-        timeSlots = found;
-        log('INFO', 'Monitor', 'Time slots updated', { slots: timeSlots });
-    }
 }
 
 function isInExamRoom(card) {
@@ -165,15 +160,7 @@ function findPatientInfo(card) {
 }
 
 function initPatient(name, inRoom) {
-    const slotData = {};
-    timeSlots.forEach(s => { slotData[s] = { hasNotification: false }; });
-    patients[name] = {
-        InExamRoom: inRoom,
-        criticalNotes: { hasNotification: false },
-        missed:        { hasNotification: false },
-        due:           { hasNotification: false },
-        timeSlots: slotData,
-    };
+    patients[name] = { InExamRoom: inRoom, taskCells: [] };
 }
 
 function hasGrandchild(node) {
@@ -183,42 +170,46 @@ function hasGrandchild(node) {
     return false;
 }
 
+function isCellCompleted(cell) {
+    return cell.querySelector('svg[data-testid="SvgCheck"]') !== null;
+}
+
 function checkNotifications(card) {
     const info = findPatientInfo(card);
     if (!info || !patients[info.name]) return;
     const { name } = info;
-    const bar = card.nextElementSibling;
-    if (!bar?.children[0]) return;
 
-    const cats = ['criticalNotes', 'missed', 'due'];
-    Array.from(bar.children[0].children).forEach((child, i) => {
-        if (i < cats.length) {
-            const cat = cats[i];
-            if (cat === 'criticalNotes') return; // silenced per current design
-            const hasNew = hasGrandchild(child);
-            if (hasNew && !patients[name][cat]?.hasNotification && patients[name].InExamRoom) {
+    const container = card.nextElementSibling?.children[0];
+    if (!container) return;
+
+    const cells = Array.from(container.children);
+    const prev  = patients[name].taskCells;
+    const next  = [];
+
+    cells.forEach((cell, i) => {
+        const hasTask   = hasGrandchild(cell);
+        const completed = hasTask && isCellCompleted(cell);
+        const was       = prev[i] ?? { hasTask: false, isCompleted: false };
+
+        if (initialized) {
+            if (hasTask && !was.hasTask && !completed) {
                 playChime('examRoomNotification');
-                log('EVENT', 'Patient', 'Exam room notification', { name, category: cat });
+                log('EVENT', 'Patient', 'Task added', { name, cell: i });
             }
-            patients[name][cat] = { hasNotification: hasNew };
-        } else {
-            const slot = timeSlots[i - cats.length];
-            if (!slot) return;
-            const hasNew = hasGrandchild(child);
-            if (hasNew && !patients[name].timeSlots[slot]?.hasNotification && patients[name].InExamRoom) {
-                playChime('examRoomNotification');
-                log('EVENT', 'Patient', 'Time slot notification', { name, slot });
+            if (completed && !was.isCompleted) {
+                playChime('taskCompleted');
+                log('EVENT', 'Patient', 'Task completed', { name, cell: i });
             }
-            patients[name].timeSlots[slot] = { hasNotification: hasNew };
         }
+        next.push({ hasTask, isCompleted: completed });
     });
+
+    patients[name].taskCells = next;
 }
 
 function runUpdate() {
     const list = getPatientList();
     if (!list) { log('INFO', 'Patient', 'PatientList not in DOM'); return; }
-
-    scanTimeSlots();
 
     const cards   = Array.from(list.querySelectorAll('div[aria-label="Patient List Item"]'));
     const current = new Set();
@@ -230,23 +221,12 @@ function runUpdate() {
         current.add(name);
 
         if (patients[name]) {
-            const wasInRoom = patients[name].InExamRoom;
             patients[name].InExamRoom = InExamRoom;
-            if (initialized && !wasInRoom && InExamRoom) {
-                playChime('patientAdded');
-                log('EVENT', 'Patient', 'Moved to exam room', { name });
-            } else if (initialized && wasInRoom && !InExamRoom) {
-                log('INFO', 'Patient', 'Left exam room — back to waiting', { name });
-            }
         } else {
             initPatient(name, InExamRoom);
             if (initialized) {
-                if (InExamRoom) {
-                    playChime('patientAdded');
-                    log('EVENT', 'Patient', 'Added — entered exam room', { name });
-                } else {
-                    log('INFO', 'Patient', 'Added — waiting room', { name });
-                }
+                playChime('patientAdded');
+                log('EVENT', 'Patient', 'Added', { name });
             } else {
                 log('INFO', 'Patient', 'Baseline', { name, InExamRoom });
             }
@@ -254,19 +234,14 @@ function runUpdate() {
     }
 
     for (const name of [...prevNames].filter(n => !current.has(n))) {
-        const wasInRoom = patients[name]?.InExamRoom;
         delete patients[name];
-        if (wasInRoom) {
-            playChime('patientRemoved');
-            log('EVENT', 'Patient', 'Removed — was in exam room', { name });
-        } else {
-            log('INFO', 'Patient', 'Removed — was in waiting room', { name });
-        }
+        playChime('patientRemoved');
+        log('EVENT', 'Patient', 'Removed', { name });
     }
 
     for (const card of cards) {
         const info = findPatientInfo(card);
-        if (info && patients[info.name]?.InExamRoom) checkNotifications(card);
+        if (info && patients[info.name]) checkNotifications(card);
     }
 
     prevNames    = new Set(current);
@@ -360,7 +335,6 @@ function startMonitoring() {
     lastUpdate    = null;
     Object.keys(patients).forEach(k => delete patients[k]);
     prevNames = new Set();
-    timeSlots = [];
     setWidgetState('active');
     safeChrome(() => chrome.storage.local.set({ vrMonitoringActive: true }));
     log('INFO', 'Monitor', 'Monitoring started');

--- a/monitor.js
+++ b/monitor.js
@@ -117,7 +117,15 @@ function drainQueue() {
     const advance = () => { if (!advanced) { advanced = true; drainQueue(); } };
     clone.onended = advance;
     clone.onerror = () => { log('ERROR', 'Audio', `Playback error for ${type}`); advance(); };
-    clone.play().catch(err => { log('ERROR', 'Audio', `play() failed for ${type}`, { error: err.message }); advance(); });
+    clone.play().catch(err => {
+        if (err?.name === 'NotAllowedError') {
+            audioPrimed = false;   // autoplay gate not unlocked — re-prime on next interaction
+            log('WARN', 'Audio', `Autoplay blocked for ${type} — will play after next page interaction`);
+        } else {
+            log('ERROR', 'Audio', `play() failed for ${type}: ${err.message}`);
+        }
+        advance();
+    });
 }
 
 // ─── Patient Tracking ─────────────────────────────────────────────────────────
@@ -543,16 +551,13 @@ window.VR_Mon_App = {
 function init() {
     injectWidget();
 
-    // Unlock Chrome's autoplay gate on the first interaction anywhere on the
-    // page. Auto-resumed monitoring has no user gesture, so priming inside
-    // startMonitoring() alone isn't enough — the first click/keypress primes it.
-    const prime = () => {
-        primeAudio();
-        document.removeEventListener('pointerdown', prime, true);
-        document.removeEventListener('keydown', prime, true);
-    };
-    document.addEventListener('pointerdown', prime, true);
-    document.addEventListener('keydown', prime, true);
+    // Unlock Chrome's autoplay gate on user interaction anywhere on the page.
+    // Auto-resumed monitoring has no user gesture, so priming inside
+    // startMonitoring() alone isn't enough. Listeners stay attached and
+    // primeAudio() is a no-op once primed, so if a chime is ever blocked again
+    // (audioPrimed reset to false) the next click re-primes.
+    document.addEventListener('pointerdown', primeAudio, true);
+    document.addEventListener('keydown', primeAudio, true);
 
     loadSettings((extensionEnabled, monitoringActive) => {
         if (!extensionEnabled) { setWidgetState('inactive'); return; }

--- a/monitor.js
+++ b/monitor.js
@@ -121,6 +121,7 @@ function drainQueue() {
         if (err?.name === 'NotAllowedError') {
             audioPrimed = false;   // autoplay gate not unlocked — re-prime on next interaction
             log('WARN', 'Audio', `Autoplay blocked for ${type} — will play after next page interaction`);
+            if (isMonitoring) setWidgetState('muted');
         } else {
             log('ERROR', 'Audio', `play() failed for ${type}: ${err.message}`);
         }
@@ -214,7 +215,9 @@ function checkNotifications(card, name) {
     const { active, completed } = countTasks(container);
     const prev = p.taskCounts;
 
-    log('INFO', 'Patient', 'Task counts', { name, prev, now: { active, completed } });
+    if (!prev || prev.active !== active || prev.completed !== completed) {
+        log('INFO', 'Patient', 'Task counts changed', { name, prev, now: { active, completed } });
+    }
 
     if (initialized && prev) {
         for (let k = prev.active; k < active; k++) {
@@ -245,13 +248,13 @@ function runUpdate() {
 
     const current = new Set([...cardInfos.values()].map(i => i.name));
 
-    // If no patient could be identified (zero cards or all cards un-parseable)
-    // but we already know about patients, VetRadar is mid-remount — skip this
-    // cycle entirely. Without this guard a single null from findPatientInfo
-    // puts the patient in the removal loop and wipes their taskCounts, causing
-    // the next task event to be silently re-baselined instead of chiming.
-    if (current.size === 0 && prevNames.size > 0) {
-        log('INFO', 'Patient', 'No parseable patients — skipping (possible remount)');
+    // Never act on an empty scan. The list element can exist before its cards
+    // render (startup) or briefly during a VetRadar remount. Acting on zero
+    // patients would either flip the baseline (false "Added" for everyone on
+    // the next scan) or wipe taskCounts (missed task chimes). Skip entirely —
+    // initialized stays false until we actually see a patient.
+    if (current.size === 0) {
+        if (prevNames.size > 0) log('INFO', 'Patient', 'No parseable patients — skipping (possible remount)');
         return;
     }
 
@@ -302,8 +305,12 @@ function onMutation() {
 
         const n = Object.keys(patients).length;
         const w = document.getElementById('vr-monitor-widget');
-        if (w) w.title = `VetRadar Monitoring — Active\n${n} patient${n !== 1 ? 's' : ''} | update #${updateCount}`;
-        setWidgetState('active');
+        if (audioPrimed) {
+            if (w) w.title = `VetRadar Monitoring — Active\n${n} patient${n !== 1 ? 's' : ''} | update #${updateCount}`;
+            setWidgetState('active');
+        } else {
+            setWidgetState('muted');
+        }
     } catch (err) {
         errCount++;
         log('ERROR', 'Monitor', 'runUpdate threw', { message: err.message, stack: err.stack });
@@ -355,14 +362,24 @@ function stopObserver() {
 
 // Play every sound at volume 0 so Chrome's autoplay gate is unlocked before any
 // real event fires. Must be called from within a user-gesture handler to work.
+// audioPrimed flips to true only when a play() actually resolves, so the widget
+// state reflects whether sound will really work.
 let audioPrimed = false;
 function primeAudio() {
     if (audioPrimed) return;
-    audioPrimed = true;
     for (const a of Object.values(audioEl)) {
         const clone = a.cloneNode();
         clone.volume = 0;
-        clone.play().then(() => clone.pause()).catch(() => { audioPrimed = false; });
+        const p = clone.play();
+        if (!p) continue;
+        p.then(() => {
+            clone.pause();
+            if (!audioPrimed) {
+                audioPrimed = true;
+                log('INFO', 'Audio', 'Autoplay gate unlocked — sound enabled');
+                if (isMonitoring) setWidgetState('active');
+            }
+        }).catch(() => {});
     }
 }
 
@@ -393,7 +410,7 @@ function startMonitoring() {
     Object.keys(patients).forEach(k => delete patients[k]);
     prevNames = new Set();
     primeAudio();
-    setWidgetState('active');
+    setWidgetState(audioPrimed ? 'active' : 'muted');
     safeChrome(() => chrome.storage.local.set({ vrMonitoringActive: true }));
     log('INFO', 'Monitor', 'Monitoring started', { instance: INSTANCE_ID, by: callerLine() });
     startListWatcher();
@@ -422,10 +439,15 @@ const WIDGET_CSS = `
     }
     #vr-monitor-widget:hover { transform:scale(1.1); }
     #vr-monitor-widget.active { background-color:#15803d; }
+    #vr-monitor-widget.muted  { background-color:#d97706; animation:vr-pulse-amber 1.6s ease-in-out infinite; }
     #vr-monitor-widget.error  { background-color:#b91c1c; animation:vr-pulse 1.4s ease-in-out infinite; }
     @keyframes vr-pulse {
         0%,100% { box-shadow:0 2px 8px rgba(185,28,28,0.4); }
         50%      { box-shadow:0 0 18px 4px rgba(185,28,28,0.85); }
+    }
+    @keyframes vr-pulse-amber {
+        0%,100% { box-shadow:0 2px 8px rgba(217,119,6,0.4); }
+        50%      { box-shadow:0 0 18px 4px rgba(217,119,6,0.85); }
     }
 `;
 const ICON_OFF = `<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><line x1="23" y1="9" x2="17" y2="15"/><line x1="17" y1="9" x2="23" y2="15"/></svg>`;
@@ -442,7 +464,9 @@ function injectWidget() {
     w.title = 'VetRadar Monitoring — click to start';
     document.body.appendChild(w);
     w.addEventListener('click', () => {
+        // pointerdown already fired primeAudio via the document listener.
         if (w.classList.contains('error') || !isMonitoring) startMonitoring();
+        else if (w.classList.contains('muted')) primeAudio();  // enable sound, keep monitoring
         else stopMonitoring();
     });
 }
@@ -450,10 +474,13 @@ function injectWidget() {
 function setWidgetState(state) {
     const w = document.getElementById('vr-monitor-widget');
     if (!w) return;
-    w.classList.remove('active', 'error');
+    w.classList.remove('active', 'error', 'muted');
     if (state === 'active') {
         w.classList.add('active'); w.innerHTML = ICON_ON;
         // tooltip is updated by onMutation with live patient count
+    } else if (state === 'muted') {
+        w.classList.add('muted'); w.innerHTML = ICON_OFF;
+        w.title = 'VetRadar Monitoring — ACTIVE, but sound is paused.\nClick anywhere on the page to enable sound.';
     } else if (state === 'error') {
         w.classList.add('error'); w.innerHTML = ICON_OFF;
         w.title = 'VetRadar Monitoring — error (click to retry)';

--- a/monitor.js
+++ b/monitor.js
@@ -206,10 +206,15 @@ function checkNotifications(card, name) {
     if (!p) return;
 
     const container = card.nextElementSibling?.children[0];
-    if (!container) return;
+    if (!container) {
+        log('WARN', 'Patient', 'No task container found', { name });
+        return;
+    }
 
     const { active, completed } = countTasks(container);
     const prev = p.taskCounts;
+
+    log('INFO', 'Patient', 'Task counts', { name, prev, now: { active, completed } });
 
     if (initialized && prev) {
         for (let k = prev.active; k < active; k++) {

--- a/monitor.js
+++ b/monitor.js
@@ -222,6 +222,15 @@ function runUpdate() {
     if (!list) { log('INFO', 'Patient', 'PatientList not in DOM'); return; }
 
     const cards     = Array.from(list.querySelectorAll('div[aria-label="Patient List Item"]'));
+
+    // If the list exists but has zero cards and we already know about patients,
+    // VetRadar is mid-remount — skip this update entirely to avoid false removals
+    // that would wipe taskCounts and cause missed chimes when cards reappear.
+    if (cards.length === 0 && prevNames.size > 0) {
+        log('INFO', 'Patient', 'No cards visible — skipping (possible remount)');
+        return;
+    }
+
     const current   = new Set();
     const cardInfos = new Map();
 
@@ -328,6 +337,18 @@ function stopObserver() {
 
 // ─── Monitor Control ──────────────────────────────────────────────────────────
 
+// Play every sound at volume 0 on the first user click so Chrome's autoplay
+// gate is unlocked before any real event fires. Without this, the first chime
+// after a hands-free monitoring reconnect fails with "no user gesture" even
+// though the user clicked the widget at startup.
+function primeAudio() {
+    for (const a of Object.values(audioEl)) {
+        const clone = a.cloneNode();
+        clone.volume = 0;
+        clone.play().then(() => clone.pause()).catch(() => {});
+    }
+}
+
 let isMonitoring  = false;
 let userActivated = false;
 let initialized   = false;
@@ -346,6 +367,7 @@ function startMonitoring() {
     lastUpdate    = null;
     Object.keys(patients).forEach(k => delete patients[k]);
     prevNames = new Set();
+    primeAudio();
     setWidgetState('active');
     safeChrome(() => chrome.storage.local.set({ vrMonitoringActive: true }));
     log('INFO', 'Monitor', 'Monitoring started');

--- a/monitor.js
+++ b/monitor.js
@@ -368,6 +368,14 @@ let updateCount   = 0;
 let errCount      = 0;
 let lastUpdate    = null;
 const MAX_ERRORS  = 5;
+const INSTANCE_ID = Math.random().toString(36).slice(2, 7);
+
+// Returns the first stack frame outside this function — i.e. who called us.
+function callerLine() {
+    const stack = (new Error().stack || '').split('\n').map(s => s.trim());
+    // [0]='Error', [1]=callerLine, [2]=start/stopMonitoring, [3]=actual caller
+    return stack[3] || stack[2] || '?';
+}
 
 function startMonitoring() {
     if (!cfg.isActive) { log('WARN', 'Monitor', 'Start blocked — extension disabled via toolbar'); return; }
@@ -382,7 +390,7 @@ function startMonitoring() {
     primeAudio();
     setWidgetState('active');
     safeChrome(() => chrome.storage.local.set({ vrMonitoringActive: true }));
-    log('INFO', 'Monitor', 'Monitoring started');
+    log('INFO', 'Monitor', 'Monitoring started', { instance: INSTANCE_ID, by: callerLine() });
     startListWatcher();
 }
 
@@ -393,7 +401,7 @@ function stopMonitoring() {
     setWidgetState('inactive');
     reportStatus('inactive');
     safeChrome(() => chrome.storage.local.set({ vrMonitoringActive: false }));
-    log('INFO', 'Monitor', 'Monitoring stopped');
+    log('INFO', 'Monitor', 'Monitoring stopped', { instance: INSTANCE_ID, by: callerLine() });
 }
 
 // ─── Widget ───────────────────────────────────────────────────────────────────
@@ -561,6 +569,8 @@ function init() {
     // (audioPrimed reset to false) the next click re-primes.
     document.addEventListener('pointerdown', primeAudio, true);
     document.addEventListener('keydown', primeAudio, true);
+
+    log('INFO', 'Monitor', 'Content script loaded', { instance: INSTANCE_ID, frame: window === window.top ? 'top' : 'iframe', url: location.href });
 
     loadSettings((extensionEnabled, monitoringActive) => {
         if (!extensionEnabled) { setWidgetState('inactive'); return; }

--- a/monitor.js
+++ b/monitor.js
@@ -405,13 +405,6 @@ function updateBadge() {
 }
 const INSTANCE_ID = Math.random().toString(36).slice(2, 7);
 
-// Returns the first stack frame outside this function — i.e. who called us.
-function callerLine() {
-    const stack = (new Error().stack || '').split('\n').map(s => s.trim());
-    // [0]='Error', [1]=callerLine, [2]=start/stopMonitoring, [3]=actual caller
-    return stack[3] || stack[2] || '?';
-}
-
 function startMonitoring() {
     if (!cfg.isActive) { log('WARN', 'Monitor', 'Start blocked — extension disabled via toolbar'); return; }
     isMonitoring  = true;
@@ -427,7 +420,7 @@ function startMonitoring() {
     setWidgetState(audioPrimed ? 'active' : 'muted');
     updateBadge();
     safeChrome(() => chrome.storage.local.set({ vrMonitoringActive: true }));
-    log('INFO', 'Monitor', 'Monitoring started', { instance: INSTANCE_ID, by: callerLine() });
+    log('INFO', 'Monitor', 'Monitoring started', { instance: INSTANCE_ID });
     startListWatcher();
 }
 
@@ -440,7 +433,7 @@ function stopMonitoring() {
     updateBadge();
     reportStatus('inactive');
     safeChrome(() => chrome.storage.local.set({ vrMonitoringActive: false }));
-    log('INFO', 'Monitor', 'Monitoring stopped', { instance: INSTANCE_ID, by: callerLine() });
+    log('INFO', 'Monitor', 'Monitoring stopped', { instance: INSTANCE_ID });
 }
 
 // ─── Widget ───────────────────────────────────────────────────────────────────
@@ -489,7 +482,6 @@ function injectWidget() {
     w.title = 'VetRadar Monitoring — click to start';
     document.body.appendChild(w);
     w.addEventListener('click', () => {
-        // pointerdown already fired primeAudio via the document listener.
         if (w.classList.contains('error') || !isMonitoring) startMonitoring();
         else if (w.classList.contains('muted')) primeAudio();  // enable sound, keep monitoring
         else stopMonitoring();

--- a/monitor.js
+++ b/monitor.js
@@ -113,9 +113,11 @@ function drainQueue() {
     if (!audioEl[type]?.src) { drainQueue(); return; }
     const clone = audioEl[type].cloneNode();
     clone.volume = Math.min(1, cfg.chimeVolume * (cfg[volKey[type]] ?? 1.0));
-    clone.onended = drainQueue;
-    clone.onerror = () => { log('ERROR', 'Audio', `Playback error for ${type}`); drainQueue(); };
-    clone.play().catch(err => { log('ERROR', 'Audio', `play() failed for ${type}`, { error: err.message }); drainQueue(); });
+    let advanced = false;
+    const advance = () => { if (!advanced) { advanced = true; drainQueue(); } };
+    clone.onended = advance;
+    clone.onerror = () => { log('ERROR', 'Audio', `Playback error for ${type}`); advance(); };
+    clone.play().catch(err => { log('ERROR', 'Audio', `play() failed for ${type}`, { error: err.message }); advance(); });
 }
 
 // ─── Patient Tracking ─────────────────────────────────────────────────────────
@@ -149,7 +151,10 @@ function findPatientInfo(card) {
         const raw = findNameInSubtree(sib);
         if (!raw) continue;
         for (const stored of Object.keys(patients)) {
-            if (stored.includes(raw) || raw.includes(stored)) {
+            if (stored === raw) return { name: stored, InExamRoom: isInExamRoom(card) };
+        }
+        for (const stored of Object.keys(patients)) {
+            if (stored.startsWith(raw) || raw.startsWith(stored)) {
                 return { name: stored, InExamRoom: isInExamRoom(card) };
             }
         }
@@ -174,17 +179,25 @@ function isCellCompleted(cell) {
     return cell.querySelector('svg[data-testid="SvgCheck"]') !== null;
 }
 
-function checkNotifications(card) {
-    const info = findPatientInfo(card);
-    if (!info || !patients[info.name]) return;
-    const { name } = info;
+function checkNotifications(card, name) {
+    if (!patients[name]) return;
 
     const container = card.nextElementSibling?.children[0];
     if (!container) return;
 
     const cells = Array.from(container.children);
     const prev  = patients[name].taskCells;
-    const next  = [];
+
+    if (prev.length > 0 && cells.length !== prev.length) {
+        patients[name].taskCells = cells.map(c => {
+            const hasTask = hasGrandchild(c);
+            return { hasTask, isCompleted: hasTask && isCellCompleted(c) };
+        });
+        log('INFO', 'Patient', 'Column count changed — resyncing', { name, from: prev.length, to: cells.length });
+        return;
+    }
+
+    const next = [];
 
     cells.forEach((cell, i) => {
         const hasTask   = hasGrandchild(cell);
@@ -211,13 +224,15 @@ function runUpdate() {
     const list = getPatientList();
     if (!list) { log('INFO', 'Patient', 'PatientList not in DOM'); return; }
 
-    const cards   = Array.from(list.querySelectorAll('div[aria-label="Patient List Item"]'));
-    const current = new Set();
+    const cards     = Array.from(list.querySelectorAll('div[aria-label="Patient List Item"]'));
+    const current   = new Set();
+    const cardInfos = new Map();
 
     for (const card of cards) {
         const info = findPatientInfo(card);
         if (!info) continue;
         const { name, InExamRoom } = info;
+        cardInfos.set(card, info);
         current.add(name);
 
         if (patients[name]) {
@@ -239,9 +254,8 @@ function runUpdate() {
         log('EVENT', 'Patient', 'Removed', { name });
     }
 
-    for (const card of cards) {
-        const info = findPatientInfo(card);
-        if (info && patients[info.name]) checkNotifications(card);
+    for (const [card, info] of cardInfos) {
+        if (patients[info.name]) checkNotifications(card, info.name);
     }
 
     prevNames    = new Set(current);
@@ -344,6 +358,7 @@ function startMonitoring() {
 function stopMonitoring() {
     isMonitoring = false;
     stopObserver();
+    audioQueue.length = 0;
     setWidgetState('inactive');
     reportStatus('inactive');
     safeChrome(() => chrome.storage.local.set({ vrMonitoringActive: false }));

--- a/monitor.js
+++ b/monitor.js
@@ -122,7 +122,7 @@ function drainQueue() {
 
 // ─── Patient Tracking ─────────────────────────────────────────────────────────
 
-const patients = {};       // { [name]: { InExamRoom, taskCells[] } }
+const patients = {};       // { [name]: { InExamRoom, taskCounts:{active,completed}|null } }
 let prevNames  = new Set();
 
 function getPatientList() {
@@ -165,7 +165,7 @@ function findPatientInfo(card) {
 }
 
 function initPatient(name, inRoom) {
-    patients[name] = { InExamRoom: inRoom, taskCells: [] };
+    patients[name] = { InExamRoom: inRoom, taskCounts: null };
 }
 
 function hasGrandchild(node) {
@@ -179,45 +179,42 @@ function isCellCompleted(cell) {
     return cell.querySelector('svg[data-testid="SvgCheck"]') !== null;
 }
 
+// Count task-bearing cells, ignoring the Critical Notes column (always child 0).
+// Robust to column shifts and to the grid collapsing to 1 cell when a patient
+// has no tasks then expanding to the full column set when the first task lands.
+function countTasks(container) {
+    let active = 0, completed = 0;
+    Array.from(container.children).forEach((cell, i) => {
+        if (i === 0) return;              // Critical Notes column — not a task (handled separately later)
+        if (!hasGrandchild(cell)) return; // empty time/status cell
+        if (isCellCompleted(cell)) completed++;
+        else active++;
+    });
+    return { active, completed };
+}
+
 function checkNotifications(card, name) {
-    if (!patients[name]) return;
+    const p = patients[name];
+    if (!p) return;
 
     const container = card.nextElementSibling?.children[0];
     if (!container) return;
 
-    const cells = Array.from(container.children);
-    const prev  = patients[name].taskCells;
+    const { active, completed } = countTasks(container);
+    const prev = p.taskCounts;
 
-    if (prev.length > 0 && cells.length !== prev.length) {
-        patients[name].taskCells = cells.map(c => {
-            const hasTask = hasGrandchild(c);
-            return { hasTask, isCompleted: hasTask && isCellCompleted(c) };
-        });
-        log('INFO', 'Patient', 'Column count changed — resyncing', { name, from: prev.length, to: cells.length });
-        return;
+    if (initialized && prev) {
+        for (let k = prev.active; k < active; k++) {
+            playChime('examRoomNotification');
+            log('EVENT', 'Patient', 'Task added', { name, active });
+        }
+        for (let k = prev.completed; k < completed; k++) {
+            playChime('taskCompleted');
+            log('EVENT', 'Patient', 'Task completed', { name, completed });
+        }
     }
 
-    const next = [];
-
-    cells.forEach((cell, i) => {
-        const hasTask   = hasGrandchild(cell);
-        const completed = hasTask && isCellCompleted(cell);
-        const was       = prev[i] ?? { hasTask: false, isCompleted: false };
-
-        if (initialized) {
-            if (hasTask && !was.hasTask && !completed) {
-                playChime('examRoomNotification');
-                log('EVENT', 'Patient', 'Task added', { name, cell: i });
-            }
-            if (completed && !was.isCompleted) {
-                playChime('taskCompleted');
-                log('EVENT', 'Patient', 'Task completed', { name, cell: i });
-            }
-        }
-        next.push({ hasTask, isCompleted: completed });
-    });
-
-    patients[name].taskCells = next;
+    p.taskCounts = { active, completed };
 }
 
 function runUpdate() {

--- a/monitor.js
+++ b/monitor.js
@@ -230,25 +230,28 @@ function runUpdate() {
     if (!list) { log('INFO', 'Patient', 'PatientList not in DOM'); return; }
 
     const cards     = Array.from(list.querySelectorAll('div[aria-label="Patient List Item"]'));
+    const cardInfos = new Map();
 
-    // If the list exists but has zero cards and we already know about patients,
-    // VetRadar is mid-remount — skip this update entirely to avoid false removals
-    // that would wipe taskCounts and cause missed chimes when cards reappear.
-    if (cards.length === 0 && prevNames.size > 0) {
-        log('INFO', 'Patient', 'No cards visible — skipping (possible remount)');
+    // Parse pass: resolve all patient names before touching any state.
+    for (const card of cards) {
+        const info = findPatientInfo(card);
+        if (info) cardInfos.set(card, info);
+    }
+
+    const current = new Set([...cardInfos.values()].map(i => i.name));
+
+    // If no patient could be identified (zero cards or all cards un-parseable)
+    // but we already know about patients, VetRadar is mid-remount — skip this
+    // cycle entirely. Without this guard a single null from findPatientInfo
+    // puts the patient in the removal loop and wipes their taskCounts, causing
+    // the next task event to be silently re-baselined instead of chiming.
+    if (current.size === 0 && prevNames.size > 0) {
+        log('INFO', 'Patient', 'No parseable patients — skipping (possible remount)');
         return;
     }
 
-    const current   = new Set();
-    const cardInfos = new Map();
-
-    for (const card of cards) {
-        const info = findPatientInfo(card);
-        if (!info) continue;
+    for (const [, info] of cardInfos) {
         const { name, InExamRoom } = info;
-        cardInfos.set(card, info);
-        current.add(name);
-
         if (patients[name]) {
             patients[name].InExamRoom = InExamRoom;
         } else {

--- a/monitor.js
+++ b/monitor.js
@@ -337,15 +337,16 @@ function stopObserver() {
 
 // ─── Monitor Control ──────────────────────────────────────────────────────────
 
-// Play every sound at volume 0 on the first user click so Chrome's autoplay
-// gate is unlocked before any real event fires. Without this, the first chime
-// after a hands-free monitoring reconnect fails with "no user gesture" even
-// though the user clicked the widget at startup.
+// Play every sound at volume 0 so Chrome's autoplay gate is unlocked before any
+// real event fires. Must be called from within a user-gesture handler to work.
+let audioPrimed = false;
 function primeAudio() {
+    if (audioPrimed) return;
+    audioPrimed = true;
     for (const a of Object.values(audioEl)) {
         const clone = a.cloneNode();
         clone.volume = 0;
-        clone.play().then(() => clone.pause()).catch(() => {});
+        clone.play().then(() => clone.pause()).catch(() => { audioPrimed = false; });
     }
 }
 
@@ -541,6 +542,18 @@ window.VR_Mon_App = {
 
 function init() {
     injectWidget();
+
+    // Unlock Chrome's autoplay gate on the first interaction anywhere on the
+    // page. Auto-resumed monitoring has no user gesture, so priming inside
+    // startMonitoring() alone isn't enough — the first click/keypress primes it.
+    const prime = () => {
+        primeAudio();
+        document.removeEventListener('pointerdown', prime, true);
+        document.removeEventListener('keydown', prime, true);
+    };
+    document.addEventListener('pointerdown', prime, true);
+    document.addEventListener('keydown', prime, true);
+
     loadSettings((extensionEnabled, monitoringActive) => {
         if (!extensionEnabled) { setWidgetState('inactive'); return; }
         if (monitoringActive) startMonitoring();

--- a/options.html
+++ b/options.html
@@ -256,6 +256,29 @@
             <button class="reset-button" id="resetPatientRemoved">Reset</button>
             <button id="playLibraryPatientRemoved">Play</button>
         </div>
+
+        <!-- Task Completed Sound -->
+        <div class="sound-row">
+            <input type="checkbox" id="enableTaskCompleted" checked>
+            <label for="enableTaskCompleted">Task Completed Sound</label>
+            <select id="libraryTaskCompleted">
+                <option value="mixkit-bell-notification-933.mp3">Bell Notification</option>
+                <option value="3_tone_chime-99718.mp3">3 Tone Chime</option>
+                <option value="BuddyIn.mp3">Buddy In</option>
+                <option value="Goodbye.mp3">Goodbye</option>
+                <option value="simple-notification-152054.mp3">Simple Notification</option>
+                <option value="mixkit-doorbell-single-press-333.mp3">Doorbell Single Press</option>
+            </select>
+            <div class="volume-slider">
+                <input type="range" id="volumeLibraryTaskCompleted" min="0" max="1" step="0.05" value="1.0">
+                <span id="volumeLibraryTaskCompletedValue">100%</span>
+            </div>
+            <div class="dropzone" id="dropzoneTaskCompleted" tabindex="0">
+                Drag & drop or click to select a file
+            </div>
+            <button class="reset-button" id="resetTaskCompleted">Reset</button>
+            <button id="playLibraryTaskCompleted">Play</button>
+        </div>
     </div>
 
     <!-- Action Buttons -->

--- a/options.js
+++ b/options.js
@@ -22,6 +22,12 @@ const SOUNDS = {
         keys:     { enabled: 'enablePatientRemoved', fileName: 'patientRemovedFileName',
                     fileData: 'patientRemovedFileData', volume: 'patientRemovedVolume' },
     },
+    taskCompleted: {
+        label:    'Task Completed',
+        defaults: { enabled: true, fileName: 'mixkit-bell-notification-933.mp3', fileData: null, volume: 1.0 },
+        keys:     { enabled: 'enableTaskCompleted', fileName: 'taskCompletedFileName',
+                    fileData: 'taskCompletedFileData', volume: 'taskCompletedVolume' },
+    },
 };
 
 // ─── DOM helpers ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Task completed sound** — new fourth sound type wired end-to-end: `monitor.js` detection, `options.js` config, `options.html` UI row (checkbox, dropdown, volume slider, dropzone, reset, play)
- **Count-based task detection** — replaced position-based `taskCells[]` tracking with `countTasks()` that counts active/completed cells by content, not index. Immune to VetRadar's grid collapsing to 1 cell (no tasks) then expanding to 10 (first task added), which previously caused all task chimes to silently fail
- **Fires for all board patients** — removed the old `InExamRoom` gate; task and patient sounds now trigger for every patient on the board
- **DOM remount safety** — `current.size === 0` guard in `runUpdate()` skips empty scans caused by VetRadar briefly unmounting and remounting the PatientList. Prevents false patient-added events on startup and taskCounts being wiped mid-session
- **Amber "muted" widget state** — when Chrome's autoplay policy blocks sound (e.g. after navigating into a patient record and hitting VetRadar's back button, which reloads the document with no prior user gesture), the widget turns amber with a pulsing glow instead of staying green. Tooltip explains the situation
- **Missed-chime badge counter** — a red badge on the widget increments each time a chime is blocked while muted, mirroring the unread-message counter on a phone. Clears automatically when the user clicks the page and the autoplay gate unlocks
- **Click-to-unlock** — clicking the amber widget calls `primeAudio()` directly (keeps monitoring running). Persistent `pointerdown`/`keydown` listeners on the document re-prime on any page interaction without requiring a widget click
- **Audio queue robustness** — one-shot `advance` flag prevents double-drain when both `onerror` and `play().catch` fire for the same clone

## Test plan

- [ ] Reload extension, open VetRadar patient list, click widget → turns green, baseline scan logs patients
- [ ] Add a task to a patient → exam room notification chime plays
- [ ] Complete a task → task completed chime plays
- [ ] Add a patient to the board → patient added chime plays
- [ ] Remove a patient → patient removed chime plays
- [ ] Navigate into a patient record via VetRadar (not browser), hit back → widget turns amber
- [ ] While amber, add a task in a separate window → badge increments, no sound
- [ ] Click anywhere on the patient list tab → widget turns green, badge clears
- [ ] Open extension options, change sounds/volumes, save → new sounds play on next event
- [ ] Hard-reload page → monitoring auto-resumes, widget amber until first click

https://claude.ai/code/session_01WX198pn9MrWrbfswZZDAe5

---
_Generated by [Claude Code](https://claude.ai/code/session_01WX198pn9MrWrbfswZZDAe5)_