### PR TITLE
Fix audio path migration and improve empty board detection

### DIFF
--- a/monitor.js
+++ b/monitor.js
@@ -87,11 +87,16 @@ function extURL(filename) {
     catch { log('ERROR', 'Audio', 'Extension context invalidated — cannot resolve URL'); return ''; }
 }
 
+// Migrate flat filenames saved before the Audio/ subfolder was introduced.
+const AUDIO_FILES = new Set(['BuddyIn.mp3','Goodbye.mp3','3_tone_chime-99718.mp3',
+    'mixkit-bell-notification-933.mp3','simple-notification-152054.mp3','mixkit-doorbell-single-press-333.mp3']);
+function normPath(f) { return f && !f.startsWith('Audio/') && !f.startsWith('data:') && AUDIO_FILES.has(f) ? 'Audio/' + f : f; }
+
 function loadSounds(result) {
-    audioEl.patientAdded.src          = result.patientAddedFileData         || extURL(result.patientAddedFileName         || 'Audio/BuddyIn.mp3');
-    audioEl.patientRemoved.src        = result.patientRemovedFileData       || extURL(result.patientRemovedFileName       || 'Audio/Goodbye.mp3');
-    audioEl.examRoomNotification.src  = result.examRoomNotificationFileData || extURL(result.examRoomNotificationFileName || 'Audio/3_tone_chime-99718.mp3');
-    audioEl.taskCompleted.src         = result.taskCompletedFileData        || extURL(result.taskCompletedFileName        || 'Audio/mixkit-bell-notification-933.mp3');
+    audioEl.patientAdded.src          = result.patientAddedFileData         || extURL(normPath(result.patientAddedFileName)         || 'Audio/BuddyIn.mp3');
+    audioEl.patientRemoved.src        = result.patientRemovedFileData       || extURL(normPath(result.patientRemovedFileName)       || 'Audio/Goodbye.mp3');
+    audioEl.examRoomNotification.src  = result.examRoomNotificationFileData || extURL(normPath(result.examRoomNotificationFileName) || 'Audio/3_tone_chime-99718.mp3');
+    audioEl.taskCompleted.src         = result.taskCompletedFileData        || extURL(normPath(result.taskCompletedFileName)        || 'Audio/mixkit-bell-notification-933.mp3');
     for (const a of Object.values(audioEl)) a.load();
 }
 

--- a/monitor.js
+++ b/monitor.js
@@ -254,15 +254,34 @@ function runUpdate() {
 
     const current = new Set([...cardInfos.values()].map(i => i.name));
 
-    // Never act on an empty scan. The list element can exist before its cards
-    // render (startup) or briefly during a VetRadar remount. Acting on zero
-    // patients would either flip the baseline (false "Added" for everyone on
-    // the next scan) or wipe taskCounts (missed task chimes). Skip entirely —
-    // initialized stays false until we actually see a patient.
     if (current.size === 0) {
-        if (prevNames.size > 0) log('INFO', 'Patient', 'No parseable patients — skipping (possible remount)');
+        if (cards.length === 0 && prevNames.size > 0 && !emptyBoardTimer) {
+            // No card elements at all — could be a genuine empty board or a
+            // brief remount zero-state. Confirm after 1.2s: if still empty, fire removals.
+            log('INFO', 'Patient', 'Board appears empty — confirming...');
+            emptyBoardTimer = setTimeout(() => {
+                emptyBoardTimer = null;
+                const pl = getPatientList();
+                if (!pl) return;
+                const still = pl.querySelector('div[aria-label="Patient List Item"]');
+                if (!still && prevNames.size > 0) {
+                    for (const name of [...prevNames]) {
+                        delete patients[name];
+                        playChime('patientRemoved');
+                        log('EVENT', 'Patient', 'Removed', { name });
+                    }
+                    prevNames = new Set();
+                }
+            }, 1200);
+        } else if (cards.length > 0) {
+            // Cards exist but names unparseable — React mid-render, skip cleanly.
+            if (emptyBoardTimer) { clearTimeout(emptyBoardTimer); emptyBoardTimer = null; }
+            if (prevNames.size > 0) log('INFO', 'Patient', 'No parseable patients — skipping (remount)');
+        }
         return;
     }
+    // Parseable patients present — cancel any pending empty-board removal.
+    if (emptyBoardTimer) { clearTimeout(emptyBoardTimer); emptyBoardTimer = null; }
 
     for (const [, info] of cardInfos) {
         const { name, InExamRoom } = info;
@@ -397,6 +416,7 @@ let updateCount     = 0;
 let errCount        = 0;
 let lastUpdate      = null;
 let mutedChimeCount = 0;
+let emptyBoardTimer = null;
 const MAX_ERRORS    = 5;
 
 function updateBadge() {
@@ -434,6 +454,7 @@ function stopMonitoring() {
     stopObserver();
     audioQueue.length = 0;
     mutedChimeCount = 0;
+    if (emptyBoardTimer) { clearTimeout(emptyBoardTimer); emptyBoardTimer = null; }
     setWidgetState('inactive');
     updateBadge();
     reportStatus('inactive');


### PR DESCRIPTION
## Summary
This PR addresses two issues: (1) migrating audio file paths that were saved before the Audio/ subfolder was introduced, and (2) improving the robustness of patient removal detection when the board briefly appears empty during React remounts.

## Key Changes

- **Audio path migration**: Added `normPath()` function that automatically prepends `Audio/` to flat filenames that were saved in the old format, while preserving already-migrated paths and data URIs. This ensures backward compatibility with existing user settings.

- **Empty board detection**: Replaced the simple empty-check with a more sophisticated approach that:
  - Distinguishes between a genuinely empty board and a temporary React remount zero-state
  - Implements a 1.2-second confirmation timer before firing patient removal events
  - Verifies the board is still empty by checking for actual card DOM elements before processing removals
  - Cancels the timer if parseable patients appear before confirmation completes

- **State management**: Added `emptyBoardTimer` variable to track the pending confirmation and properly clean it up on monitoring stop.

## Implementation Details

The empty board detection now checks both the parsed `cardInfos` and the actual DOM card elements (`cards.length`). This prevents false positives during React component remounts where the data might temporarily be unavailable but the DOM structure is being rebuilt. The 1.2-second delay allows the UI to stabilize before making irreversible decisions about patient removal.

https://claude.ai/code/session_01WX198pn9MrWrbfswZZDAe5